### PR TITLE
update to server.py to allow only timeformat API request (not iana or offset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ GET /time?iso_time=2026-02-11T16:00:00Z&display_format=short
 #### Response Example in JSON
 ```JSON
 {
+   "formatted":"Feb 11, 2026, 04:00 PM",
+   "iso_time":"2026-02-11T16:00:00Z",
+   "tz":null
 }
 ```
 

--- a/server.py
+++ b/server.py
@@ -88,11 +88,13 @@ def convert_datetime(iso_time, display_format=None, iana=None, offset=None):
     dt = parse_iso_time(iso_time)
 
     # Check either iana or offset is provided
-    if (iana is None and offset is None) or (iana is not None and offset is not None):
+    # Chris updated to IF to allow for if display_format is provided, but not a value for iana or offset
+    if iana is not None and offset is not None:
         raise HTTPException(status_code=400, detail="use iana or offset but not both")
     
     # Apply appropriate conversion using astimezone method
     # https://docs.python.org/3/library/datetime.html#datetime.datetime.astimezone Accessed 19 February 2026
+    tz_used = None
     if iana is not None:
         try:
             # https://docs.python.org/3/library/zoneinfo.html Accessed 19 February 2026
@@ -101,7 +103,7 @@ def convert_datetime(iso_time, display_format=None, iana=None, offset=None):
         except ZoneInfoNotFoundError:
             HTTPException(status_code=400, detail="ZoneInfo error")
         tz_used = iana
-    else:
+    elif offset is not None:
         dt = dt.astimezone(parse_offset(offset))
         tz_used = offset
 


### PR DESCRIPTION
Chris updated to IF to allow for if display_format is provided, but not a value for iana or offset.

- Code Smell: Duplicate Code and Inconsistent Conventions. The function convert_datetime() didn't take into account if neither iana or offset is provided (inconsistent convention). 
- Fix Applied: To avoid duplication of code, I included an IF statement to validate for whether either param is present in the function and act accordingly.
